### PR TITLE
Add close action with reporting

### DIFF
--- a/PA_BE/Controllers/PermissionApplicationsController.cs
+++ b/PA_BE/Controllers/PermissionApplicationsController.cs
@@ -67,4 +67,30 @@ public class PermissionApplicationsController(DataContext context) : BaseApiCont
 
         return Ok(request);
     }
+
+    [HttpPost("{id}/close")]
+    public async Task<ActionResult> CloseApplication(int id, CloseApplicationDTO request)
+    {
+        var app = await context.PermissionApplications
+            .Include(pa => pa.Employee)
+            .Include(pa => pa.Licence)
+            .FirstOrDefaultAsync(pa => pa.Id == id);
+
+        if (app == null) return NotFound();
+
+        var report = new Report
+        {
+            EmployeeId = app.EmployeeId,
+            EmployeeName = app.Employee.FirstName + " " + app.Employee.LastName,
+            LicenceName = app.Licence.ApplicationName,
+            IsGrant = app.IsGrant,
+            Note = request.Note
+        };
+
+        context.Reports.Add(report);
+        context.PermissionApplications.Remove(app);
+        await context.SaveChangesAsync();
+
+        return Ok();
+    }
 }

--- a/PA_BE/Controllers/ReportsController.cs
+++ b/PA_BE/Controllers/ReportsController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PermAdminAPI.Data;
+using PermAdminAPI.DTOs;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PermAdminAPI.Controllers;
+
+public class ReportsController(DataContext context) : BaseApiController
+{
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<ReportDTO>>> GetReports()
+    {
+        var reports = await context.Reports
+            .Select(r => new ReportDTO
+            {
+                Id = r.Id,
+                EmployeeId = r.EmployeeId,
+                EmployeeName = r.EmployeeName,
+                LicenceName = r.LicenceName,
+                Action = r.IsGrant ? "granted" : "revoked",
+                Note = r.Note
+            })
+            .ToListAsync();
+
+        return Ok(reports);
+    }
+}

--- a/PA_BE/DTOs/CloseApplicationDTO.cs
+++ b/PA_BE/DTOs/CloseApplicationDTO.cs
@@ -1,0 +1,7 @@
+namespace PermAdminAPI.DTOs
+{
+    public class CloseApplicationDTO
+    {
+        public string Note { get; set; }
+    }
+}

--- a/PA_BE/DTOs/ReportDTO.cs
+++ b/PA_BE/DTOs/ReportDTO.cs
@@ -1,0 +1,12 @@
+namespace PermAdminAPI.DTOs
+{
+    public class ReportDTO
+    {
+        public int Id { get; set; }
+        public int EmployeeId { get; set; }
+        public string EmployeeName { get; set; }
+        public string LicenceName { get; set; }
+        public string Action { get; set; }
+        public string Note { get; set; }
+    }
+}

--- a/PA_BE/Data/DataContext.cs
+++ b/PA_BE/Data/DataContext.cs
@@ -15,6 +15,7 @@ namespace PermAdminAPI.Data
         public DbSet<EmployeeLicence> EmployeeLicences {get; set;}
         public DbSet<LicenceInstance> LicenceInstances {get; set;}
         public DbSet<PermissionApplication> PermissionApplications { get; set; }
+        public DbSet<Report> Reports { get; set; }
     }
 }
 

--- a/PA_BE/Models/Report.cs
+++ b/PA_BE/Models/Report.cs
@@ -1,0 +1,12 @@
+namespace PermAdminAPI.Models
+{
+    public class Report
+    {
+        public int Id { get; set; }
+        public int EmployeeId { get; set; }
+        public string EmployeeName { get; set; }
+        public string LicenceName { get; set; }
+        public bool IsGrant { get; set; }
+        public string Note { get; set; }
+    }
+}

--- a/PA_FE/src/_models/Report.ts
+++ b/PA_FE/src/_models/Report.ts
@@ -1,0 +1,8 @@
+export interface Report {
+  id: number;
+  employeeId: number;
+  employeeName: string;
+  licenceName: string;
+  action: string;
+  note: string;
+}

--- a/PA_FE/src/_services/permission-application.service.ts
+++ b/PA_FE/src/_services/permission-application.service.ts
@@ -19,4 +19,8 @@ export class PermissionApplicationService {
   createApplication(app: PermissionApplication): Observable<PermissionApplication> {
     return this.http.post<PermissionApplication>(this.apiUrl, app);
   }
+
+  closeApplication(id: number, note: string): Observable<void> {
+    return this.http.post<void>(`${this.apiUrl}/${id}/close`, { note });
+  }
 }

--- a/PA_FE/src/_services/report.service.ts
+++ b/PA_FE/src/_services/report.service.ts
@@ -1,0 +1,18 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../environments/environment';
+import { Report } from '../_models/Report';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ReportService {
+  private apiUrl = `${environment.apiUrl}/reports`;
+
+  constructor(private http: HttpClient) {}
+
+  getReports(): Observable<Report[]> {
+    return this.http.get<Report[]>(this.apiUrl);
+  }
+}

--- a/PA_FE/src/app/app.component.html
+++ b/PA_FE/src/app/app.component.html
@@ -18,6 +18,9 @@
         <li class="nav-item">
           <a class="nav-link" routerLink="/permission-applications">Applications for permissions</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" routerLink="/reports">Reports</a>
+        </li>
       </ul>
 
       <div class="d-flex align-items-center gap-3">

--- a/PA_FE/src/app/app.routes.ts
+++ b/PA_FE/src/app/app.routes.ts
@@ -7,6 +7,7 @@ import { EmployeeDetailsComponent } from './employee-details/employee-details.co
 import { AssignLicenseComponent } from './assign-license/assign-license.component';
 import { LicenceDetailsComponent } from './licence-details/licence-details.component';
 import { PermissionApplicationsComponent } from './permission-applications/permission-applications.component';
+import { ReportsComponent } from './reports/reports.component';
 
 export const routes: Routes = [
   { path: '', component: EmployeeTableComponent },
@@ -19,4 +20,5 @@ export const routes: Routes = [
   { path: 'licenceDetails/:id', component: LicenceDetailsComponent },
   { path: 'assign-license/:employeeId', component: AssignLicenseComponent},
   { path: 'permission-applications', component: PermissionApplicationsComponent },
+  { path: 'reports', component: ReportsComponent },
 ];

--- a/PA_FE/src/app/permission-applications/permission-applications.component.html
+++ b/PA_FE/src/app/permission-applications/permission-applications.component.html
@@ -25,6 +25,7 @@
       <th>Full Name</th>
       <th>Permission</th>
       <th>Action</th>
+      <th></th>
     </tr>
   </thead>
   <tbody>
@@ -33,6 +34,16 @@
       <td>{{app.employeeName}}</td>
       <td>{{app.licenceName}}</td>
       <td>{{app.isGrant ? 'Grant' : 'Revoke'}}</td>
+      <td>
+        <ng-container *ngIf="closingAppId === app.id; else closeBtn">
+          <input class="form-control d-inline-block w-auto me-2" [(ngModel)]="note" placeholder="Note" />
+          <button class="btn btn-sm btn-danger me-2" (click)="confirmClose(app)">Confirm</button>
+          <button class="btn btn-sm btn-secondary" (click)="cancelClose()">Cancel</button>
+        </ng-container>
+        <ng-template #closeBtn>
+          <button class="btn btn-sm btn-warning" (click)="startClose(app.id)">Close</button>
+        </ng-template>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/PA_FE/src/app/permission-applications/permission-applications.component.ts
+++ b/PA_FE/src/app/permission-applications/permission-applications.component.ts
@@ -21,6 +21,8 @@ export class PermissionApplicationsComponent implements OnInit {
   licences: Licence[] = [];
   newApp: Partial<PermissionApplication> = { isGrant: true };
   errorMessage = '';
+  closingAppId: number | null = null;
+  note = '';
 
   constructor(
     private appService: PermissionApplicationService,
@@ -61,6 +63,25 @@ export class PermissionApplicationsComponent implements OnInit {
       error: (err) => {
         this.errorMessage = err.error;
       },
+    });
+  }
+
+  startClose(id: number): void {
+    this.closingAppId = id;
+    this.note = '';
+  }
+
+  cancelClose(): void {
+    this.closingAppId = null;
+    this.note = '';
+  }
+
+  confirmClose(app: PermissionApplication): void {
+    if (!this.note.trim()) return;
+
+    this.appService.closeApplication(app.id, this.note).subscribe(() => {
+      this.applications = this.applications.filter((a) => a.id !== app.id);
+      this.cancelClose();
     });
   }
 

--- a/PA_FE/src/app/reports/reports.component.html
+++ b/PA_FE/src/app/reports/reports.component.html
@@ -1,0 +1,18 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th>Employee ID</th>
+      <th>Full Name</th>
+      <th>Application</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let r of reports; trackBy: trackById">
+      <td>{{ r.employeeId }}</td>
+      <td>{{ r.employeeName }}</td>
+      <td>{{ r.licenceName }}</td>
+      <td>{{ r.action }}</td>
+    </tr>
+  </tbody>
+</table>

--- a/PA_FE/src/app/reports/reports.component.ts
+++ b/PA_FE/src/app/reports/reports.component.ts
@@ -1,0 +1,25 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { Report } from '../../_models/Report';
+import { ReportService } from '../../_services/report.service';
+
+@Component({
+  selector: 'app-reports',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './reports.component.html',
+  styleUrls: ['./reports.component.css'],
+})
+export class ReportsComponent implements OnInit {
+  reports: Report[] = [];
+
+  constructor(private reportService: ReportService) {}
+
+  ngOnInit(): void {
+    this.reportService.getReports().subscribe((r) => (this.reports = r));
+  }
+
+  trackById(_index: number, item: Report): number {
+    return item.id;
+  }
+}


### PR DESCRIPTION
## Summary
- allow closing permission applications with a required note that removes the application and records a report
- expose a reports endpoint and tab listing employee, application, and action

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test` *(fails: error TS18003 no inputs in tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895faf07d04832d833ec74bb22aa90a