### PR TITLE
Fix permission application error message display

### DIFF
--- a/PA_FE/src/app/permission-applications/permission-applications.component.ts
+++ b/PA_FE/src/app/permission-applications/permission-applications.component.ts
@@ -59,7 +59,16 @@ export class PermissionApplicationsComponent implements OnInit {
         this.errorMessage = '';
       },
       error: (err) => {
-        this.errorMessage = err.error;
+        if (typeof err.error === 'string') {
+          this.errorMessage = err.error;
+        } else if (err.error?.errors) {
+          const firstKey = Object.keys(err.error.errors)[0];
+          this.errorMessage = err.error.errors[firstKey][0];
+        } else if (err.error?.title) {
+          this.errorMessage = err.error.title;
+        } else {
+          this.errorMessage = 'An unexpected error occurred';
+        }
       },
     });
   }


### PR DESCRIPTION
## Summary
- properly parse error objects so permission application form shows readable messages

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No inputs were found in config file)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689607406d20832dabcba337f9d59e0d