### PR TITLE
Fix licence assignment error and format permission IDs

### DIFF
--- a/PA_BE/Controllers/PermissionApplicationsController.cs
+++ b/PA_BE/Controllers/PermissionApplicationsController.cs
@@ -19,7 +19,7 @@ public class PermissionApplicationsController(DataContext context) : BaseApiCont
             .Select(pa => new PermissionApplicationDTO
             {
                 Id = pa.Id,
-                UniqueId = pa.UniqueId.ToString(),
+                UniqueId = pa.UniqueId,
                 EmployeeId = pa.EmployeeId,
                 EmployeeName = pa.Employee.FirstName + " " + pa.Employee.LastName,
                 LicenceId = pa.LicenceId,
@@ -53,19 +53,24 @@ public class PermissionApplicationsController(DataContext context) : BaseApiCont
             return BadRequest("Employee does not have this licence");
         }
 
+        var year = DateTime.UtcNow.Year;
+        var count = await context.PermissionApplications
+            .CountAsync(pa => pa.UniqueId.EndsWith($"/{year}"));
+        var uniqueId = $"{count + 1}/{year}";
+
         var app = new PermissionApplication
         {
             EmployeeId = request.EmployeeId,
             LicenceId = request.LicenceId,
             IsGrant = request.IsGrant,
-            UniqueId = Guid.NewGuid()
+            UniqueId = uniqueId
         };
 
         context.PermissionApplications.Add(app);
         await context.SaveChangesAsync();
 
         request.Id = app.Id;
-        request.UniqueId = app.UniqueId.ToString();
+        request.UniqueId = app.UniqueId;
         request.EmployeeName = employee.FirstName + " " + employee.LastName;
         request.LicenceName = licence.ApplicationName;
 

--- a/PA_BE/Models/PermissionApplication.cs
+++ b/PA_BE/Models/PermissionApplication.cs
@@ -6,7 +6,7 @@ namespace PermAdminAPI.Models;
 public class PermissionApplication
 {
     public int Id { get; set; }
-    public Guid UniqueId { get; set; }
+    public required string UniqueId { get; set; }
     public int EmployeeId { get; set; }
     public Employee Employee { get; set; }
     public int LicenceId { get; set; }

--- a/PA_BE/Program.cs
+++ b/PA_BE/Program.cs
@@ -24,6 +24,25 @@ namespace PermAdminAPI
             {
                 var context = services.GetRequiredService<DataContext>();
                 context.Database.Migrate();
+
+                context.Database.ExecuteSqlRaw(@"CREATE TABLE IF NOT EXISTS Histories (
+                    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    EmployeeId INTEGER NOT NULL,
+                    EmployeeName TEXT,
+                    ApplicationName TEXT,
+                    Action TEXT,
+                    Note TEXT
+                );");
+
+                context.Database.ExecuteSqlRaw(@"CREATE TABLE IF NOT EXISTS PermissionApplications (
+                    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    UniqueId TEXT NOT NULL,
+                    EmployeeId INTEGER NOT NULL,
+                    LicenceId INTEGER NOT NULL,
+                    IsGrant INTEGER NOT NULL,
+                    FOREIGN KEY (EmployeeId) REFERENCES Employees(id),
+                    FOREIGN KEY (LicenceId) REFERENCES Licences(id)
+                );");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- Ensure history and permission application tables exist to prevent licence assignment failure
- Generate permission application unique IDs as sequential number/year strings

## Testing
- `apt-get update` *(fails: repository not signed)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960ccb2420832d888fa07f7ba04ae3