### PR TITLE
Make History note nullable and add migration

### DIFF
--- a/PA_BE/DTOs/HistoryDTO.cs
+++ b/PA_BE/DTOs/HistoryDTO.cs
@@ -7,6 +7,6 @@ namespace PermAdminAPI.DTOs
         public string EmployeeName { get; set; }
         public string ApplicationName { get; set; }
         public string Action { get; set; }
-        public string Note { get; set; }
+        public string? Note { get; set; }
     }
 }

--- a/PA_BE/Data/Migrations/20250717000000_HistoryNoteNullable.cs
+++ b/PA_BE/Data/Migrations/20250717000000_HistoryNoteNullable.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PermAdminAPI.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class HistoryNoteNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                CREATE TABLE Histories_temp (
+                    Id INTEGER NOT NULL CONSTRAINT PK_Histories PRIMARY KEY AUTOINCREMENT,
+                    EmployeeId INTEGER NOT NULL,
+                    EmployeeName TEXT NOT NULL,
+                    ApplicationName TEXT NOT NULL,
+                    Action TEXT NOT NULL,
+                    Note TEXT NULL
+                );
+                INSERT INTO Histories_temp (Id, EmployeeId, EmployeeName, ApplicationName, Action, Note)
+                SELECT Id, EmployeeId, EmployeeName, ApplicationName, Action, Note FROM Histories;
+                DROP TABLE Histories;
+                ALTER TABLE Histories_temp RENAME TO Histories;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                CREATE TABLE Histories_temp (
+                    Id INTEGER NOT NULL CONSTRAINT PK_Histories PRIMARY KEY AUTOINCREMENT,
+                    EmployeeId INTEGER NOT NULL,
+                    EmployeeName TEXT NOT NULL,
+                    ApplicationName TEXT NOT NULL,
+                    Action TEXT NOT NULL,
+                    Note TEXT NOT NULL
+                );
+                INSERT INTO Histories_temp (Id, EmployeeId, EmployeeName, ApplicationName, Action, Note)
+                SELECT Id, EmployeeId, EmployeeName, ApplicationName, Action, Note FROM Histories;
+                DROP TABLE Histories;
+                ALTER TABLE Histories_temp RENAME TO Histories;
+            ");
+        }
+    }
+}

--- a/PA_BE/Data/Migrations/DataContextModelSnapshot.cs
+++ b/PA_BE/Data/Migrations/DataContextModelSnapshot.cs
@@ -135,6 +135,35 @@ namespace PermAdminAPI.Data.Migrations
                     b.ToTable("LicenceInstances");
                 });
 
+            modelBuilder.Entity("PermAdminAPI.Models.History", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("Action")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("ApplicationName")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<int>("EmployeeId")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("EmployeeName")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Note")
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Histories");
+                });
+
             modelBuilder.Entity("PermAdminAPI.Models.EmployeeLicence", b =>
                 {
                     b.HasOne("PermAdminAPI.Models.Employee", "Employee")

--- a/PA_BE/Models/History.cs
+++ b/PA_BE/Models/History.cs
@@ -7,6 +7,6 @@ namespace PermAdminAPI.Models
         public string EmployeeName { get; set; }
         public string ApplicationName { get; set; }
         public string Action { get; set; }
-        public string Note { get; set; }
+        public string? Note { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- allow null Note in history model and DTO
- add EF Core migration to make Histories.Note nullable and update model snapshot

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet ef database update` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689646064ba4832dbf5f48d14c305014