### PR TITLE
Add employee filter to history view

### DIFF
--- a/PA_BE/Controllers/HistoryController.cs
+++ b/PA_BE/Controllers/HistoryController.cs
@@ -10,9 +10,16 @@ namespace PermAdminAPI.Controllers;
 public class HistoryController(DataContext context) : BaseApiController
 {
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<HistoryDTO>>> GetHistory()
+    public async Task<ActionResult<IEnumerable<HistoryDTO>>> GetHistory(string? employeeName = null)
     {
-        var history = await context.Histories
+        var query = context.Histories.AsQueryable();
+
+        if (!string.IsNullOrEmpty(employeeName))
+        {
+            query = query.Where(h => h.EmployeeName == employeeName);
+        }
+
+        var history = await query
             .Select(r => new HistoryDTO
             {
                 Id = r.Id,

--- a/PA_FE/src/_services/history.service.ts
+++ b/PA_FE/src/_services/history.service.ts
@@ -12,7 +12,8 @@ export class HistoryService {
 
   constructor(private http: HttpClient) {}
 
-  getHistory(): Observable<History[]> {
-    return this.http.get<History[]>(this.apiUrl);
+  getHistory(employeeName?: string): Observable<History[]> {
+    const options = employeeName ? { params: { employeeName } } : {};
+    return this.http.get<History[]>(this.apiUrl, options);
   }
 }

--- a/PA_FE/src/app/history/history.component.html
+++ b/PA_FE/src/app/history/history.component.html
@@ -1,3 +1,17 @@
+<select
+  class="form-select mb-3"
+  [(ngModel)]="selectedEmployeeName"
+  (change)="onEmployeeChange()"
+>
+  <option value="">All Employees</option>
+  <option
+    *ngFor="let employee of employees"
+    [value]="employee.firstName + ' ' + employee.lastName"
+  >
+    {{ employee.firstName }} {{ employee.lastName }}
+  </option>
+</select>
+
 <table class="table">
   <thead>
     <tr>

--- a/PA_FE/src/app/history/history.component.ts
+++ b/PA_FE/src/app/history/history.component.ts
@@ -1,22 +1,37 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Employee } from '../../_models/Employee';
 import { History } from '../../_models/History';
+import { EmployeeService } from '../../_services/employee.service';
 import { HistoryService } from '../../_services/history.service';
 
 @Component({
   selector: 'app-history',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   templateUrl: './history.component.html',
   styleUrls: ['./history.component.css'],
 })
 export class HistoryComponent implements OnInit {
   history: History[] = [];
-
-  constructor(private historyService: HistoryService) {}
+  employees: Employee[] = [];
+  selectedEmployeeName = '';
+  constructor(
+    private historyService: HistoryService,
+    private employeeService: EmployeeService
+  ) {}
 
   ngOnInit(): void {
-    this.historyService.getHistory().subscribe((r) => (this.history = r));
+    this.employeeService
+      .getEmployees()
+      .subscribe((e) => (this.employees = e));
+    this.onEmployeeChange();
+  }
+
+  onEmployeeChange(): void {
+    const name = this.selectedEmployeeName || undefined;
+    this.historyService.getHistory(name).subscribe((r) => (this.history = r));
   }
 
   trackById(_index: number, item: History): number {


### PR DESCRIPTION
## Summary
- Support optional `employeeName` filter in backend history endpoint.
- Add `employeeName` query parameter support in history service.
- Populate employee dropdown in history component and refresh history on selection.

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_6898b107a0f8832d87661e31a01444a3