### PR TITLE
Adjust licence expiration alerts

### DIFF
--- a/PA_FE/src/app/employee-details/employee-details.component.html
+++ b/PA_FE/src/app/employee-details/employee-details.component.html
@@ -75,7 +75,7 @@
           <td>{{ licence.licenceName }}</td>
           <td>{{ licence.assignedOn | date }}</td>
           <td>{{ licence.validTo | date }}</td>
-          <td>{{ isExpiringSoon(licence.validTo) ? 'expires within two weeks' : '' }}</td>
+          <td>{{ getExpiryStatus(licence.validTo) }}</td>
           <td>
             <button
               class="btn btn-danger btn-sm"

--- a/PA_FE/src/app/employee-details/employee-details.component.ts
+++ b/PA_FE/src/app/employee-details/employee-details.component.ts
@@ -79,13 +79,28 @@ export class EmployeeDetailsComponent implements OnInit {
   }
 
   isExpiringSoon(validTo?: string): boolean {
+    return this.getExpiryStatus(validTo) !== '';
+  }
+
+  getExpiryStatus(validTo?: string): string {
     if (!validTo) {
-      return false;
+      return '';
     }
-    const expiry = new Date(validTo);
+
     const now = new Date();
-    const twoWeeksAhead = new Date();
-    twoWeeksAhead.setDate(now.getDate() + 14);
-    return expiry <= twoWeeksAhead;
+    const expiry = new Date(validTo);
+
+    if (expiry < now) {
+      return 'expired';
+    }
+
+    const twoWeeksAhead = new Date(now);
+    twoWeeksAhead.setDate(twoWeeksAhead.getDate() + 14);
+
+    if (expiry <= twoWeeksAhead) {
+      return 'expires within two weeks';
+    }
+
+    return '';
   }
 }

--- a/PA_FE/src/app/licence-table/licence-table.component.html
+++ b/PA_FE/src/app/licence-table/licence-table.component.html
@@ -20,7 +20,7 @@
         <td>{{licence.applicationName}}</td>
         <td>{{licence.availableLicences}}</td>
         <td>{{licence.quantity}}</td>
-        <td>{{ isExpiringSoon(licence.id) ? 'expires within two weeks' : '' }}</td>
+        <td>{{ getExpiryMessage(licence.id) }}</td>
         <td>
             <button class="btn btn-primary m-2 btn-sm" (click)="showLicenceDetails(licence.id)">Details</button>
             


### PR DESCRIPTION
## Summary
- show specific expiry messaging for employee licence assignments, including an "expired" status when the date has passed
- track licence expiry status strings in the licence table so expired licences display the correct alert text

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0296e7304832d96eedf5649befa2e