### PR TITLE
Update licence details assigned employees display

### DIFF
--- a/PA_FE/src/app/licence-details/licence-details.component.html
+++ b/PA_FE/src/app/licence-details/licence-details.component.html
@@ -63,20 +63,22 @@
   </ng-template>
 
   <div class="card mt-4" *ngIf="assignedUsers.length">
-    <div class="card-header bg-secondary text-white">
+    <div class="card-header bg-primary text-white">
       <h4 class="mb-0">Assigned employees</h4>
     </div>
     <div class="card-body">
       <table class="table table-striped">
         <thead>
           <tr>
+            <th>Licence ID</th>
             <th>Employee</th>
             <th>Assigned On</th>
-            <th>Licence Valid To</th>
+            <th>Licence Expires On</th>
           </tr>
         </thead>
         <tbody>
           <tr *ngFor="let user of assignedUsers">
+            <td>{{ user.licenceId }}</td>
             <td>{{ user.employeeName || '-' }}</td>
             <td>{{ user.assignedOn ? (user.assignedOn | date) : '-' }}</td>
             <td>{{ user.validTo ? (user.validTo | date) : '-' }}</td>

--- a/PA_FE/src/app/licence-details/licence-details.component.ts
+++ b/PA_FE/src/app/licence-details/licence-details.component.ts
@@ -79,6 +79,7 @@ export class LicenceDetailsComponent implements OnInit {
         this.instances = this.instances.filter(i => i.id !== instanceId);
         this.licence!.availableLicences--;
         this.licence!.quantity--;
+        this.loadAssignedUsers(this.licence!.id);
       },
       error: err => console.error('Error deleting instance', err)
     });


### PR DESCRIPTION
## Summary
- add licence identifier column and rename expiry heading in the assigned employees table
- switch assigned employees card header to primary blue styling
- refresh assigned employee data after deleting a licence instance to drop removed assignments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02f608b80832d848179402e32f64e