### PR TITLE
Track assigned licences by instance

### DIFF
--- a/PA_BE/DTOs/AssignLicenceDTO.cs
+++ b/PA_BE/DTOs/AssignLicenceDTO.cs
@@ -6,13 +6,20 @@ namespace PermAdminAPI.DTOs;
 public class AssignLicenceDTO
 {
     public int Id { get; set; }
+
     [Required(ErrorMessage = "Employee ID is required")]
     public int EmployeeId { get; set; }
-    
+
     [Required(ErrorMessage = "Licence ID is required")]
     public int LicenceId { get; set; }
+
+    public int? LicenceInstanceId { get; set; }
+
     public string? EmployeeName { get; set; }
+
     public string? LicenceName { get; set; }
+
     public DateTime AssignedOn { get; set; }
-    public DateTime ValidTo { get; set; }
+
+    public DateTime? ValidTo { get; set; }
 }

--- a/PA_BE/DTOs/PermissionApplicationDTO.cs
+++ b/PA_BE/DTOs/PermissionApplicationDTO.cs
@@ -3,7 +3,7 @@ namespace PermAdminAPI.DTOs;
 public class PermissionApplicationDTO
 {
     public int Id { get; set; }
-    public string UniqueId { get; set; }
+    public string? UniqueId { get; set; }
     public int EmployeeId { get; set; }
     public string EmployeeName { get; set; }
     public int LicenceId { get; set; }

--- a/PA_BE/Data/Migrations/20250718000000_AddLicenceInstanceReferenceToEmployeeLicence.cs
+++ b/PA_BE/Data/Migrations/20250718000000_AddLicenceInstanceReferenceToEmployeeLicence.cs
@@ -1,0 +1,49 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PermAdminAPI.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLicenceInstanceReferenceToEmployeeLicence : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "LicenceInstanceId",
+                table: "EmployeeLicences",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmployeeLicences_LicenceInstanceId",
+                table: "EmployeeLicences",
+                column: "LicenceInstanceId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_EmployeeLicences_LicenceInstances_LicenceInstanceId",
+                table: "EmployeeLicences",
+                column: "LicenceInstanceId",
+                principalTable: "LicenceInstances",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_EmployeeLicences_LicenceInstances_LicenceInstanceId",
+                table: "EmployeeLicences");
+
+            migrationBuilder.DropIndex(
+                name: "IX_EmployeeLicences_LicenceInstanceId",
+                table: "EmployeeLicences");
+
+            migrationBuilder.DropColumn(
+                name: "LicenceInstanceId",
+                table: "EmployeeLicences");
+        }
+    }
+}

--- a/PA_BE/Data/Migrations/DataContextModelSnapshot.cs
+++ b/PA_BE/Data/Migrations/DataContextModelSnapshot.cs
@@ -83,12 +83,17 @@ namespace PermAdminAPI.Data.Migrations
                     b.Property<int>("licenceId")
                         .HasColumnType("INTEGER");
 
+                    b.Property<int?>("LicenceInstanceId")
+                        .HasColumnType("INTEGER");
+
                     b.Property<DateTime>("AssignedOn")
                         .HasColumnType("TEXT");
 
                     b.HasKey("id");
 
                     b.HasIndex("employeeId");
+
+                    b.HasIndex("LicenceInstanceId");
 
                     b.HasIndex("licenceId");
 
@@ -178,7 +183,14 @@ namespace PermAdminAPI.Data.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
+                    b.HasOne("PermAdminAPI.Models.LicenceInstance", "LicenceInstance")
+                        .WithMany()
+                        .HasForeignKey("LicenceInstanceId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
                     b.Navigation("Employee");
+
+                    b.Navigation("LicenceInstance");
 
                     b.Navigation("Licence");
                 });

--- a/PA_BE/Models/EmployeeLicence.cs
+++ b/PA_BE/Models/EmployeeLicence.cs
@@ -9,5 +9,7 @@ public class EmployeeLicence
     public Employee Employee { get; set; }
     public int licenceId { get; set; }
     public Licence Licence { get; set; }
+    public int? LicenceInstanceId { get; set; }
+    public LicenceInstance? LicenceInstance { get; set; }
     public DateTime AssignedOn { get; set; }
 }

--- a/PA_FE/src/_models/AssignLicenceDTO.ts
+++ b/PA_FE/src/_models/AssignLicenceDTO.ts
@@ -2,6 +2,7 @@ export interface AssignLicenceDTO {
   id: number; // was Id
   employeeId: number; // was EmployeeId
   licenceId: number; // was LicenceId
+  licenceInstanceId?: number;
   employeeName: string; // was EmployeeName
   licenceName: string; // was LicenceName
   assignedOn?: string;

--- a/PA_FE/src/app/licence-details/licence-details.component.html
+++ b/PA_FE/src/app/licence-details/licence-details.component.html
@@ -70,7 +70,7 @@
       <table class="table table-striped">
         <thead>
           <tr>
-            <th>Licence ID</th>
+            <th>Licence Instance ID</th>
             <th>Employee</th>
             <th>Assigned On</th>
             <th>Licence Expires On</th>
@@ -78,7 +78,7 @@
         </thead>
         <tbody>
           <tr *ngFor="let user of assignedUsers">
-            <td>{{ user.licenceId }}</td>
+            <td>{{ user.licenceInstanceId ?? '-' }}</td>
             <td>{{ user.employeeName || '-' }}</td>
             <td>{{ user.assignedOn ? (user.assignedOn | date) : '-' }}</td>
             <td>{{ user.validTo ? (user.validTo | date) : '-' }}</td>


### PR DESCRIPTION
## Summary
- link employee licence assignments to specific licence instances and expose the instance id in assignment DTOs
- ensure licence instance deletions clear related assignments and make permission application unique ids optional on input
- add a migration introducing the optional LicenceInstanceId column and update the licence details view to show instance ids

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0316e76e4832d810a45b1d3c171b7