### PR TITLE
Ensure schema for licences and permission applications

### DIFF
--- a/PA_BE/Program.cs
+++ b/PA_BE/Program.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using System.Data;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -20,34 +17,28 @@ namespace PermAdminAPI
 
             using var scope = host.Services.CreateScope();
             var services = scope.ServiceProvider;
+            var logger = services.GetRequiredService<ILogger<Program>>();
+
             try
             {
                 var context = services.GetRequiredService<DataContext>();
-                context.Database.Migrate();
 
-                context.Database.ExecuteSqlRaw(@"CREATE TABLE IF NOT EXISTS Histories (
-                    Id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    EmployeeId INTEGER NOT NULL,
-                    EmployeeName TEXT,
-                    ApplicationName TEXT,
-                    Action TEXT,
-                    Note TEXT
-                );");
+                try
+                {
+                    context.Database.Migrate();
+                }
+                catch (Exception migrateEx)
+                {
+                    logger.LogError(migrateEx, "An error occurred while applying EF Core migrations");
+                }
 
-                context.Database.ExecuteSqlRaw(@"CREATE TABLE IF NOT EXISTS PermissionApplications (
-                    Id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    UniqueId TEXT NOT NULL,
-                    EmployeeId INTEGER NOT NULL,
-                    LicenceId INTEGER NOT NULL,
-                    IsGrant INTEGER NOT NULL,
-                    FOREIGN KEY (EmployeeId) REFERENCES Employees(id),
-                    FOREIGN KEY (LicenceId) REFERENCES Licences(id)
-                );");
+                TryEnsureHistoriesTable(context, logger);
+                TryEnsurePermissionApplicationsTable(context, logger);
+                TryEnsureEmployeeLicenceInstanceColumn(context, logger);
             }
             catch (Exception ex)
             {
-                var logger = services.GetRequiredService<ILogger<Program>>();
-                logger.LogError(ex, "An error occurred during migration");
+                logger.LogError(ex, "An error occurred while initialising the database");
             }
 
             host.Run();
@@ -59,5 +50,86 @@ namespace PermAdminAPI
                 {
                     webBuilder.UseStartup<Startup>();
                 });
+
+        private static void TryEnsureHistoriesTable(DataContext context, ILogger logger)
+        {
+            try
+            {
+                context.Database.ExecuteSqlRaw(@"CREATE TABLE IF NOT EXISTS Histories (
+                    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    EmployeeId INTEGER NOT NULL,
+                    EmployeeName TEXT NOT NULL,
+                    ApplicationName TEXT NOT NULL,
+                    Action TEXT NOT NULL,
+                    Note TEXT NULL
+                );");
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to ensure Histories table");
+            }
+        }
+
+        private static void TryEnsurePermissionApplicationsTable(DataContext context, ILogger logger)
+        {
+            try
+            {
+                context.Database.ExecuteSqlRaw(@"CREATE TABLE IF NOT EXISTS PermissionApplications (
+                    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    UniqueId TEXT NOT NULL,
+                    EmployeeId INTEGER NOT NULL,
+                    LicenceId INTEGER NOT NULL,
+                    IsGrant INTEGER NOT NULL,
+                    FOREIGN KEY (EmployeeId) REFERENCES Employees(id) ON DELETE CASCADE,
+                    FOREIGN KEY (LicenceId) REFERENCES Licences(id) ON DELETE CASCADE
+                );");
+
+                context.Database.ExecuteSqlRaw(@"CREATE INDEX IF NOT EXISTS IX_PermissionApplications_EmployeeId ON PermissionApplications(EmployeeId);");
+                context.Database.ExecuteSqlRaw(@"CREATE INDEX IF NOT EXISTS IX_PermissionApplications_LicenceId ON PermissionApplications(LicenceId);");
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to ensure PermissionApplications table");
+            }
+        }
+
+        private static void TryEnsureEmployeeLicenceInstanceColumn(DataContext context, ILogger logger)
+        {
+            try
+            {
+                var connection = context.Database.GetDbConnection();
+                var previousState = connection.State;
+
+                if (previousState != ConnectionState.Open)
+                {
+                    connection.Open();
+                }
+
+                try
+                {
+                    using var command = connection.CreateCommand();
+                    command.CommandText = "SELECT 1 FROM pragma_table_info('EmployeeLicences') WHERE name = 'LicenceInstanceId' LIMIT 1;";
+                    var exists = command.ExecuteScalar() != null;
+
+                    if (!exists)
+                    {
+                        context.Database.ExecuteSqlRaw("ALTER TABLE EmployeeLicences ADD COLUMN LicenceInstanceId INTEGER NULL;");
+                    }
+
+                    context.Database.ExecuteSqlRaw(@"CREATE INDEX IF NOT EXISTS IX_EmployeeLicences_LicenceInstanceId ON EmployeeLicences(LicenceInstanceId);");
+                }
+                finally
+                {
+                    if (previousState != ConnectionState.Open)
+                    {
+                        connection.Close();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to ensure EmployeeLicences schema");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- harden application start-up so schema fixes are executed even if EF migrations fail
- automatically create the Histories and PermissionApplications tables with the expected indexes
- ensure the EmployeeLicences table always has the LicenceInstanceId column required for assigned licence lookups

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d03564d6e8832d87cb011ba26e941e